### PR TITLE
Don't reindex products after order completion

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -1,8 +1,0 @@
-Spree::Order.class_eval do
-  Spree::Order.state_machine.after_transition to: :complete, do: :reindex_order_products
-
-  def reindex_order_products
-    return unless complete?
-    products.map(&:reindex)
-  end
-end


### PR DESCRIPTION
Conversion counts are not needed.